### PR TITLE
Clamp RGB values to range 0-255 in rgb_to_hex

### DIFF
--- a/programming files/rgb_to_hex.cc
+++ b/programming files/rgb_to_hex.cc
@@ -4,6 +4,7 @@
 
 std::string rgb_to_hex(int r, int g, int b)
 {
+    // clamp to range 0, 255
     r = std::max(0, std::min(255, r));
     g = std::max(0, std::min(255, g));
     b = std::max(0, std::min(255, b));


### PR DESCRIPTION
Added clamping to ensure RGB values are within the range of 0 to 255.