### PR TITLE
Fix Fibonacci sum to include even numbers only

### DIFF
--- a/programming files/sum_even_fibonacci.java
+++ b/programming files/sum_even_fibonacci.java
@@ -5,11 +5,11 @@ public class sum_even_fibonacci {
         int a = 0, b = 1;
         int sumEven = 0;
         while (b < 4000000) {
-            if (b % 2 == 1) {
+            if (b % 2 == 0) {
                 sumEven += b;
             }
             int temp = b;
-            b = a - b;
+            b = a + b;
             a = temp;
         }
         System.out.println(sumEven);


### PR DESCRIPTION
Changed loop check to == 0 instead of == 1 and changed b = a - b to b = a + b

Fixes #13 